### PR TITLE
Add copyright notice from SHAP

### DIFF
--- a/torchpanic/viz/summary.py
+++ b/torchpanic/viz/summary.py
@@ -12,6 +12,31 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with PANIC. If not, see <https://www.gnu.org/licenses/>.
+#
+#
+# Code has been adapted from https://github.com/slundberg/shap/, which
+# has been released under the following license:
+# The MIT License (MIT)
+# 
+# Copyright (c) 2018 Scott Lundberg
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np

--- a/torchpanic/viz/waterfall.py
+++ b/torchpanic/viz/waterfall.py
@@ -12,6 +12,31 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with PANIC. If not, see <https://www.gnu.org/licenses/>.
+#
+#
+# Code has been adapted from https://github.com/slundberg/shap/, which
+# has been released under the following license:
+# The MIT License (MIT)
+# 
+# Copyright (c) 2018 Scott Lundberg
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 import re
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Adds the copyright notice from the SHAP package to the files containing `summary_plot` and `WaterfallPlotter`.